### PR TITLE
fix: update environment variable to set production environment in bac…

### DIFF
--- a/.aws/backend-task-definition.json
+++ b/.aws/backend-task-definition.json
@@ -19,7 +19,7 @@
       ],
       "environment": [
         {"name": "AWS_REGION", "value": "us-east-1"},
-        {"name": "USE_LOCAL_STORAGE", "value": "false"}
+        {"name": "ENVIRONMENT", "value": "production"}
       ],
       "logConfiguration": {
         "logDriver": "awslogs",


### PR DESCRIPTION
This pull request makes a minor update to the `.aws/backend-task-definition.json` configuration file, replacing the `USE_LOCAL_STORAGE` environment variable with an `ENVIRONMENT` variable set to `"production"`.

- [`.aws/backend-task-definition.json`](diffhunk://#diff-0795c536d24c102126e0f60247c2ca651d566d71cdbbc4718897c5202a8446c7L22-R22): Replaced the `USE_LOCAL_STORAGE` environment variable with `ENVIRONMENT`, set to `"production"`, to better reflect deployment context.…kend task definition