### PR TITLE
fix: update CORS origins to include production domains in config

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ import time
 from fastapi import FastAPI, UploadFile, File, BackgroundTasks, HTTPException, Form
 from app.routers import uploadUrl, createJob, getDownload, getUserJobs, createSheetMusic, createCheckoutSession, webhooks, getDashboardMetrics, updateProfile, deleteJob  # , transcription, midi_ops
 from fastapi.middleware.cors import CORSMiddleware
+from app.config_loader import Config
 
 load_dotenv()
 
@@ -16,7 +17,8 @@ app = FastAPI()
 # app.include_router(transcription.router, prefix="/transcribe", tags=["transcription"])
 # app.include_router(midi_ops.router, prefix="/midi", tags=["midi"])
 
-cors_origins = os.getenv("CORS_ALLOWED_ORIGINS")
+cors_origins = Config.CORS_ORIGINS
+
 if cors_origins:
     origins = [origin.strip() for origin in cors_origins.split(",")]
 else:

--- a/packages/pianofi_config/config.py
+++ b/packages/pianofi_config/config.py
@@ -92,7 +92,7 @@ def get_cors_origins() -> list:
     if env == "development":
         from dotenv import load_dotenv
         load_dotenv()
-        origins = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000")
+        origins = os.getenv("CORS_ALLOWED_ORIGINS", "https://www.pianofi.ca,https://pianofi.ca")
         return origins.split(",")
     
     # Production - get from Parameter Store
@@ -103,7 +103,7 @@ def get_cors_origins() -> list:
         return response['Parameter']['Value'].split(",")
     except Exception as e:
         # Fallback to restrictive CORS in production
-        return ["https://yourdomain.com"]
+        return ["https://www.pianofi.ca"]
     
 @lru_cache()
 def get_redis_url() -> str:


### PR DESCRIPTION
This pull request updates how CORS origins are configured in both the FastAPI backend and the shared configuration module. The changes standardize CORS settings to use the official Pianofi domains and ensure consistent loading of configuration values across environments.

**CORS configuration updates:**

* Changed the backend's CORS origins source in `main.py` to use `Config.CORS_ORIGINS` instead of reading directly from environment variables, ensuring a single source of truth for configuration. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R9) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L19-R21)
* Updated the default allowed CORS origins in development and production environments in `config.py` to use "https://www.pianofi.ca,https://pianofi.ca" instead of localhost or placeholder domains. [[1]](diffhunk://#diff-7ec1e70d382aec0f7784a050dcf496a6762a063dd4ea1c55ff7459b25eddcd05L95-R95) [[2]](diffhunk://#diff-7ec1e70d382aec0f7784a050dcf496a6762a063dd4ea1c55ff7459b25eddcd05L106-R106)