### PR TITLE
refactor: simplify CORS origins handling in main.py

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,13 +17,16 @@ app = FastAPI()
 # app.include_router(transcription.router, prefix="/transcribe", tags=["transcription"])
 # app.include_router(midi_ops.router, prefix="/midi", tags=["midi"])
 
-cors_origins = Config.CORS_ORIGINS
+origins = Config.CORS_ORIGINS
 
-if cors_origins:
-    origins = [origin.strip() for origin in cors_origins.split(",")]
-else:
-    # Fallback origins for development
-    origins = ["*"]  # or ["http://localhost:3000", "http://frontend:3000"]
+# if cors_origins:
+#     if isinstance(cors_origins, str):
+#         origins = [o.strip() for o in cors_origins.split(",")]
+#     else:
+#         origins = [o.strip() for o in cors_origins]
+# else:
+#     # Fallback origins for development
+#     origins = ["*"]  # or ["http://localhost:3000", "http://frontend:3000"]
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
This pull request simplifies the CORS (Cross-Origin Resource Sharing) configuration in `backend/app/main.py` by removing the logic that handled different formats of `CORS_ORIGINS` and fallback development origins. Now, it uses the value of `Config.CORS_ORIGINS` directly.

CORS configuration simplification:

* Replaced the previous logic that parsed and set the `origins` list for CORS with a direct assignment from `Config.CORS_ORIGINS`, and commented out the code that handled string splitting and fallback origins.