### PR TITLE
fix: enhance transcription status display with additional states

### DIFF
--- a/frontend/app/dashboard/components/transcriptionItem.tsx
+++ b/frontend/app/dashboard/components/transcriptionItem.tsx
@@ -70,14 +70,20 @@ const TranscriptionItem: FC<TranscriptionItemProps> = ({
                   ? "default"
                   : transcription.status === "processing"
                   ? "secondary"
-                  : "destructive"
+                  : transcription.status === "failed"
+                  ? "destructive"
+                  : "outline" // For initialized/queued
               }
             >
               {transcription.status === "completed"
                 ? "Completed"
                 : transcription.status === "processing"
                 ? "Processing"
-                : "Failed"}
+                : transcription.status === "failed"
+                ? "Failed"
+                : transcription.status === "queued"
+                ? "Queued"
+                : "Initializing"}
             </Badge>
             {transcription.status === "processing" && (
               <div className="w-24">


### PR DESCRIPTION
This pull request makes a small but important improvement to the status badge logic in the `TranscriptionItem` component. The change ensures that badge styles and labels correctly reflect all possible transcription statuses, including "failed", "queued", and "initialized".

* Improved status badge rendering in `frontend/app/dashboard/components/transcriptionItem.tsx` to handle "failed", "queued", and "initialized" transcription statuses with appropriate label and style.