### PR TITLE
Issue #91 fix - solved same page redirection, fixed extra long timer, hidden login/signup form component

### DIFF
--- a/frontend/components/ui/header.tsx
+++ b/frontend/components/ui/header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import React, { useState } from "react";
+import React, { useEffect, useState, useTransition } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Menu, Music } from "lucide-react";
@@ -19,16 +19,33 @@ export function Header() {
   const pathname = usePathname();
   const isMobile = useIsMobile();
   const [isRedirecting, setIsRedirecting] = useState(false);
+  const [isPending, startTransition] = useTransition();
 
   const handleNavigation = (path: string) => {
     if (pathname === path) return;
     setIsRedirecting(true);
-    router.push(path);
 
-    setTimeout(() => {
-      setIsRedirecting(false);
-    }, 10000);
+    startTransition(() => {
+      router.push(path);
+    });
   };
+
+  useEffect(() => {
+   if (isRedirecting) setIsRedirecting(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!isPending && isRedirecting) setIsRedirecting(false);
+  }, [isPending, isRedirecting]);
+
+  useEffect(() => {
+    if (!isRedirecting) return;
+    const prev = document.documentElement.style.overflow;
+    document.documentElement.style.overflow = "hidden";
+    return () => {
+      document.documentElement.style.overflow = prev || "";
+    };
+  }, [isRedirecting]);
 
   if (isRedirecting) {
     return (


### PR DESCRIPTION
Hey! Sorry the fix took a bit longer than expected, free time problems on my part. I have implemented a fix that doesn't allow the user to redirect to the path they are already on, rendering the login/signup buttons in the header non-responsive in such case. As for the form visible during loading screen, I ensured the form is not visible by overlaying it by the loading screen and applied a scroll lock just to be sure - this could probably be done much better by a different aproach to rendering instead of covering up already rendered stuff. There was also a 10 seconds long timer that artificially prolonged the loading time much more than was actually needed, so I set the loading time to be tied directly to the route transmition. I propose this fix for now, I believe it takes care of all the problems without any major changes affecting the current code. If you're okay with it, I would like to keep working on it a bit more to see whether I can make the rendering a bit more effective. Also, if there is anything else about this fix that doesn't seem right, I'll be happy to work on a new fix too.