### PR TITLE
Update default monthly limit for free users to 3 and modify error handling in FileUploader component

### DIFF
--- a/backend/app/routers/getDashboardMetrics.py
+++ b/backend/app/routers/getDashboardMetrics.py
@@ -53,7 +53,7 @@ async def get_dashboard_metrics(
     )
 
     subscription_row = subscription_result.fetchone()
-    monthly_limit = subscription_row[0] if subscription_row else 1  # Default to 1 for free users
+    monthly_limit = subscription_row[0] if subscription_row else 3  # Default to 3 for free users
     
     # Calculate transcriptions left this month
     transcriptions_left = None if monthly_limit is None else max(0, monthly_limit - this_month_count)

--- a/frontend/app/dashboard/components/fileUploader.tsx
+++ b/frontend/app/dashboard/components/fileUploader.tsx
@@ -108,10 +108,8 @@ const FileUploader: FC<FileUploaderProps> = ({
       metrics.transcriptions_left !== null &&
       metrics.transcriptions_left <= 0
     ) {
-      toast.error(
-        "You have reached your monthly transcription limit. Please upgrade your plan."
-      );
-      onUpgradeRequired();
+      toast.error("You have reached your monthly transcription limit.");
+      // onUpgradeRequired(); uncomment when payment flow is ready
       return;
     }
 


### PR DESCRIPTION
This pull request makes two small but important changes related to the user experience for free users and the transcription limit notification. The monthly transcription limit for free users is increased, and the upgrade prompt behavior is adjusted while the payment flow is still under development.

- **Subscription and Limit Updates**
  * Increased the default monthly transcription limit for free users from 1 to 3 in `getDashboardMetrics.py`, allowing free users to transcribe more files each month.

- **User Notification Adjustments**
  * Modified the file uploader's limit-reached behavior to only show an error toast without prompting for an upgrade, since the payment flow is not yet ready (`fileUploader.tsx`).