### PR TITLE
Issue 86: Fix Midi to XML Convert

### DIFF
--- a/amtworkers/tasks/midiToXml.py
+++ b/amtworkers/tasks/midiToXml.py
@@ -350,6 +350,7 @@ class MidiToMusicXML:
                 avg_treble = sum(n['midi_note'] for n in treble_notes) / len(treble_notes) if treble_notes else 66
                 avg_bass = sum(n['midi_note'] for n in bass_notes) / len(bass_notes) if bass_notes else 54
 
+                # Step 4: assign middle notes based on proximity
                 for n in middle_notes:
                     dist_to_treble = abs(n['midi_note'] - avg_treble)
                     dist_to_bass = abs(n['midi_note'] - avg_bass)
@@ -358,6 +359,62 @@ class MidiToMusicXML:
                         treble_notes.append(n)
                     else:
                         bass_notes.append(n)
+                
+                # Step 5: enforce 9-note (=14 semitone) range per hand
+                MAX_RANGE = 14
+                MAX_ITER = 20  # prevent infinite loops
+
+                def get_range(notes):
+                    if not notes:
+                        return 0
+                    notes_sorted = sorted(notes, key=lambda n: n['midi_note'])
+                    return notes_sorted[-1]['midi_note'] - notes_sorted[0]['midi_note']
+
+                def average_pitch(notes, default):
+                    return sum(n['midi_note'] for n in notes) / len(notes) if notes else default
+
+                def enforce_range(treble_notes, bass_notes):
+                    iteration = 0
+
+                    while iteration < MAX_ITER:
+                        iteration += 1
+                        changed = False
+
+                        avg_treble = average_pitch(treble_notes, 66)
+                        avg_bass = average_pitch(bass_notes, 54)
+
+                        # Treble too wide?
+                        if get_range(treble_notes) > MAX_RANGE:
+                            center = avg_treble
+                            farthest = max(treble_notes, key=lambda n: abs(n['midi_note'] - center))
+                            # Move only if it makes bass more balanced
+                            if abs(farthest['midi_note'] - avg_bass) < abs(farthest['midi_note'] - avg_treble):
+                                treble_notes.remove(farthest)
+                                bass_notes.append(farthest)
+                                changed = True
+                            else:
+                                # Otherwise, just drop it or break to avoid looping
+                                treble_notes.remove(farthest)
+                                break
+
+                        # Bass too wide?
+                        if get_range(bass_notes) > MAX_RANGE:
+                            center = avg_bass
+                            farthest = max(bass_notes, key=lambda n: abs(n['midi_note'] - center))
+                            if abs(farthest['midi_note'] - avg_treble) < abs(farthest['midi_note'] - avg_bass):
+                                bass_notes.remove(farthest)
+                                treble_notes.append(farthest)
+                                changed = True
+                            else:
+                                bass_notes.remove(farthest)
+                                break
+
+                        if not changed:
+                            break
+
+                    return treble_notes, bass_notes
+
+                treble_notes, bass_notes = enforce_range(treble_notes, bass_notes)
                 
                 # Handle treble part
                 if treble_notes:

--- a/picogenworkers/tasks/midiToXml.py
+++ b/picogenworkers/tasks/midiToXml.py
@@ -350,6 +350,7 @@ class MidiToMusicXML:
                 avg_treble = sum(n['midi_note'] for n in treble_notes) / len(treble_notes) if treble_notes else 66
                 avg_bass = sum(n['midi_note'] for n in bass_notes) / len(bass_notes) if bass_notes else 54
 
+                # Step 4: assign middle notes based on proximity
                 for n in middle_notes:
                     dist_to_treble = abs(n['midi_note'] - avg_treble)
                     dist_to_bass = abs(n['midi_note'] - avg_bass)
@@ -358,6 +359,62 @@ class MidiToMusicXML:
                         treble_notes.append(n)
                     else:
                         bass_notes.append(n)
+                
+                # Step 5: enforce 9-note (=14 semitone) range per hand
+                MAX_RANGE = 14
+                MAX_ITER = 20  # prevent infinite loops
+
+                def get_range(notes):
+                    if not notes:
+                        return 0
+                    notes_sorted = sorted(notes, key=lambda n: n['midi_note'])
+                    return notes_sorted[-1]['midi_note'] - notes_sorted[0]['midi_note']
+
+                def average_pitch(notes, default):
+                    return sum(n['midi_note'] for n in notes) / len(notes) if notes else default
+
+                def enforce_range(treble_notes, bass_notes):
+                    iteration = 0
+
+                    while iteration < MAX_ITER:
+                        iteration += 1
+                        changed = False
+
+                        avg_treble = average_pitch(treble_notes, 66)
+                        avg_bass = average_pitch(bass_notes, 54)
+
+                        # Treble too wide?
+                        if get_range(treble_notes) > MAX_RANGE:
+                            center = avg_treble
+                            farthest = max(treble_notes, key=lambda n: abs(n['midi_note'] - center))
+                            # Move only if it makes bass more balanced
+                            if abs(farthest['midi_note'] - avg_bass) < abs(farthest['midi_note'] - avg_treble):
+                                treble_notes.remove(farthest)
+                                bass_notes.append(farthest)
+                                changed = True
+                            else:
+                                # Otherwise, just drop it or break to avoid looping
+                                treble_notes.remove(farthest)
+                                break
+
+                        # Bass too wide?
+                        if get_range(bass_notes) > MAX_RANGE:
+                            center = avg_bass
+                            farthest = max(bass_notes, key=lambda n: abs(n['midi_note'] - center))
+                            if abs(farthest['midi_note'] - avg_treble) < abs(farthest['midi_note'] - avg_bass):
+                                bass_notes.remove(farthest)
+                                treble_notes.append(farthest)
+                                changed = True
+                            else:
+                                bass_notes.remove(farthest)
+                                break
+
+                        if not changed:
+                            break
+
+                    return treble_notes, bass_notes
+
+                treble_notes, bass_notes = enforce_range(treble_notes, bass_notes)
                 
                 # Handle treble part
                 if treble_notes:


### PR DESCRIPTION
Fixing the part that separates notes into treble and bass clef.

Rather than having a hard number set and separating notes to clefs like that (doesn't pick up context), we have some guaranteed treble and bass clef notes (F4/G3) and anything in between will be decided by if its closer to notes that are already in the bass clef or to notes already in the treble clef. This ensures we keep the musical "context" of which hand should be playing.

Can be made more dynamic by testing with different values to mark guaranteed treble and bass clefs and see what produces better results.